### PR TITLE
Новый парсинг дат для /visit и /unvisit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1974,9 +1974,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1986,9 +1986,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.9"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3583,6 +3583,7 @@ dependencies = [
  "itertools 0.14.0",
  "log",
  "pretty_env_logger",
+ "regex",
  "serde",
  "serde_derive",
  "sqlx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,4 @@ clap = { version = "4.5", features = ["derive"] }
 axum = "0.8"
 tower-http = { version = "0.6", features = ["catch-panic"] }
 derive-where = "1.6"
+regex = "1.12.2"

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -68,7 +68,7 @@ fn strip_command(text: &str) -> &str {
 }
 
 fn parse_visit_text(author: Uid, msg: &str) -> Result<VisitUpdate> {
-    let ParsedMessage { day, purpose } = parse_message_with_date(msg)?;
+    let ParsedMessage { day, purpose } = parse_message_with_date(today(), msg)?;
 
     Ok(VisitUpdate {
         person: author,

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -23,6 +23,7 @@ use teloxide::{
 use crate::{
     backend::Backend,
     config::TelegramBotConfig,
+    date::{ParsedMessage, parse_message_with_date},
     visits::{Visit, VisitStatus, VisitUpdate},
 };
 use crate::{backend::Uid, utils::today};
@@ -66,33 +67,15 @@ fn strip_command(text: &str) -> &str {
     }
 }
 
-fn parse_day_purpose(text: &str) -> (NaiveDate, &str) {
-    if let Some(purpose) = text.strip_prefix("завтра") {
-        return (today() + TimeDelta::days(1), purpose.trim());
-    }
-    if let Some(purpose) = text.strip_prefix("послезавтра") {
-        return (today() + TimeDelta::days(2), purpose.trim());
-    }
+fn parse_visit_text(author: Uid, msg: &str) -> Result<VisitUpdate> {
+    let ParsedMessage { day, purpose } = parse_message_with_date(msg)?;
 
-    let Ok((date, purpose)) = NaiveDate::parse_and_remainder(text, "%Y-%m-%d") else {
-        return (today(), text.trim());
-    };
-
-    (date, purpose.trim())
-}
-
-fn parse_visit_text(author: Uid, msg: &str) -> VisitUpdate {
-    let (day, purpose) = parse_day_purpose(msg);
-    VisitUpdate {
+    Ok(VisitUpdate {
         person: author,
-        day,
-        purpose: if purpose.is_empty() {
-            None
-        } else {
-            Some(purpose.to_owned())
-        },
+        day: day.unwrap_or_else(|| today()),
+        purpose,
         status: VisitStatus::Planned,
-    }
+    })
 }
 
 fn format_close_date(date: NaiveDate) -> Option<&'static str> {
@@ -724,10 +707,6 @@ impl<B: Backend> TelegramBot<B> {
         Uid(msg.from.as_ref().expect("message to have author").id)
     }
 
-    fn parse_visit_message(msg: &Message) -> VisitUpdate {
-        parse_visit_text(Self::message_author(msg), Self::message_text(msg))
-    }
-
     fn common_modifiers(send_message: JsonRequest<SendMessage>) -> JsonRequest<SendMessage> {
         send_message
             .disable_notification(true)
@@ -763,7 +742,11 @@ impl<B: Backend> TelegramBot<B> {
     }
 
     async fn handle_plan_visit(&self, msg: &Message) -> Result<()> {
-        let visit_update = Self::parse_visit_message(msg);
+        let Ok(visit_update) = parse_visit_text(Self::message_author(msg), Self::message_text(msg))
+        else {
+            self.send_message_reply(msg, "Несуществующая дата").await?;
+            return Ok(());
+        };
 
         self.backend()
             .plan_visit(visit_update.person, visit_update.day, visit_update.purpose)
@@ -775,7 +758,11 @@ impl<B: Backend> TelegramBot<B> {
     }
 
     async fn handle_unplan_visit(&self, msg: &Message) -> Result<()> {
-        let visit_update = Self::parse_visit_message(msg);
+        let Ok(visit_update) = parse_visit_text(Self::message_author(msg), Self::message_text(msg))
+        else {
+            self.send_message_reply(msg, "Несуществующая дата").await?;
+            return Ok(());
+        };
 
         self.backend()
             .unplan_visit(visit_update.person, visit_update.day)
@@ -901,6 +888,10 @@ impl<B: Backend> TelegramBot<B> {
     }
 
     async fn handle_callback(&self, q: &CallbackQuery) -> Result<()> {
+        let msg = q
+            .regular_message()
+            .ok_or_else(|| anyhow::anyhow!("message too old"))?;
+
         let Some(data) = q.data.as_deref() else {
             return Ok(());
         };
@@ -908,12 +899,20 @@ impl<B: Backend> TelegramBot<B> {
         let author = Uid(q.from.id);
 
         if data.starts_with("/planvisit") {
-            let visit_update = parse_visit_text(author, strip_command(data));
+            let Ok(visit_update) = parse_visit_text(author, strip_command(data)) else {
+                self.send_message_reply(msg, "Неправильная дата").await?;
+                return Ok(());
+            };
+
             self.backend()
                 .plan_visit(visit_update.person, visit_update.day, visit_update.purpose)
                 .await?;
         } else if data.starts_with("/unplanvisit") {
-            let visit_update = parse_visit_text(author, strip_command(data));
+            let Ok(visit_update) = parse_visit_text(author, strip_command(data)) else {
+                self.send_message_reply(msg, "Неправильная дата").await?;
+                return Ok(());
+            };
+
             self.backend()
                 .unplan_visit(visit_update.person, visit_update.day)
                 .await?;

--- a/src/date.rs
+++ b/src/date.rs
@@ -1,5 +1,3 @@
-use crate::utils::{now, today};
-
 use anyhow::{Result, bail};
 use chrono::{Datelike, NaiveDate, TimeDelta, Weekday};
 use regex::{Match, Regex};
@@ -28,30 +26,30 @@ static YMD: LazyLock<Regex> =
 static DMY: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^(\d{1,2})[-\.](\d{1,2})[-\.](\d{4})[\s\.,]*(\s+.*)?$").unwrap());
 
-pub fn parse_message_with_date(text: &str) -> Result<ParsedMessage> {
+pub fn parse_message_with_date(base_date: NaiveDate, text: &str) -> Result<ParsedMessage> {
     if let Some(c) = RELATIVE_DAY.captures(text) {
         Ok(ParsedMessage {
-            day: Some(calculate_relative_day(&c[1])),
+            day: Some(calculate_relative_day(base_date, &c[1])),
             purpose: parse_purpose(c.get(2)),
         })
     } else if let Some(c) = NEXT_WEEKDAY.captures(text) {
         Ok(ParsedMessage {
-            day: Some(calculate_next_weekday(&c[4])),
+            day: Some(calculate_next_weekday(base_date, &c[4])),
             purpose: parse_purpose(c.get(12)),
         })
     } else if let Some(c) = DAY_MONTH.captures(text) {
         Ok(ParsedMessage {
-            day: Some(parse_day_month_date(&c[1], &c[2])?),
+            day: Some(parse_day_month_date(base_date, &c[1], &c[2])?),
             purpose: parse_purpose(c.get(3)),
         })
     } else if let Some(c) = YMD.captures(text) {
         Ok(ParsedMessage {
-            day: Some(parse_ymd_date(&c[1], &c[2], &c[3])?),
+            day: Some(parse_ymd_date(base_date, &c[1], &c[2], &c[3])?),
             purpose: parse_purpose(c.get(4)),
         })
     } else if let Some(c) = DMY.captures(text) {
         Ok(ParsedMessage {
-            day: Some(parse_ymd_date(&c[3], &c[2], &c[1])?),
+            day: Some(parse_ymd_date(base_date, &c[3], &c[2], &c[1])?),
             purpose: parse_purpose(c.get(4)),
         })
     } else {
@@ -75,19 +73,17 @@ fn parse_purpose(purpose: Option<Match<'_>>) -> Option<String> {
     }
 }
 
-fn calculate_relative_day(relative_day: &str) -> NaiveDate {
+fn calculate_relative_day(base_date: NaiveDate, relative_day: &str) -> NaiveDate {
     match relative_day.to_lowercase().as_str() {
-        "сегодня" => today(),
-        "завтра" => today() + TimeDelta::days(1),
-        "послезавтра" => today() + TimeDelta::days(2),
+        "сегодня" => base_date,
+        "завтра" => base_date + TimeDelta::days(1),
+        "послезавтра" => base_date + TimeDelta::days(2),
         _ => unreachable!("invalid word `{relative_day}`"),
     }
 }
 
-fn calculate_next_weekday(weekday: &str) -> NaiveDate {
-    let now = now();
-
-    let weekday = match weekday {
+fn calculate_next_weekday(base_date: NaiveDate, weekday: &str) -> NaiveDate {
+    let target_weekday = match weekday {
         "понедельник" | "пон" | "пн" => Weekday::Mon,
         "вторник" | "вт" => Weekday::Tue,
         "среду" | "ср" => Weekday::Wed,
@@ -98,19 +94,23 @@ fn calculate_next_weekday(weekday: &str) -> NaiveDate {
         _ => unreachable!("invalid word `{weekday}`"),
     };
 
-    let days = now.weekday().days_since(weekday);
-    let date = if days == 0 {
-        now + TimeDelta::weeks(1)
+    let current_weekday = base_date.weekday().number_from_monday();
+    let target_weekday = target_weekday.number_from_monday();
+
+    let days = if current_weekday == target_weekday{
+        7
+    }else if current_weekday < target_weekday {
+        target_weekday - current_weekday
     } else {
-        now + TimeDelta::days(days.into())
+        7 - current_weekday + target_weekday
     };
 
-    date.date_naive()
+    println!("current_weekday = {current_weekday}, target_weekday = {target_weekday}, diff = {days}");
+
+    base_date + TimeDelta::days(days.into())
 }
 
-fn parse_day_month_date(day: &str, month: &str) -> Result<NaiveDate> {
-    let now = now();
-
+fn parse_day_month_date(base_date: NaiveDate, day: &str, month: &str) -> Result<NaiveDate> {
     let day = day.parse().unwrap();
 
     let month = match month {
@@ -129,19 +129,17 @@ fn parse_day_month_date(day: &str, month: &str) -> Result<NaiveDate> {
         _ => unreachable!("invalid word `{month}`"),
     };
 
-    let year = if month <= now.month() && day < now.day() {
-        now.year() + 1
+    let year = if month <= base_date.month() && day < base_date.day() {
+        base_date.year() + 1
     } else {
-        now.year()
+        base_date.year()
     };
 
     NaiveDate::from_ymd_opt(year, month, day)
         .ok_or_else(|| anyhow::anyhow!("invalid date: {}-{}-{}", year, month, day))
 }
 
-fn parse_ymd_date(year: &str, month: &str, day: &str) -> Result<NaiveDate> {
-    let now = today();
-
+fn parse_ymd_date(base_date: NaiveDate, year: &str, month: &str, day: &str) -> Result<NaiveDate> {
     let year = year.parse().unwrap();
     let month = month.parse().unwrap();
     let day = day.parse().unwrap();
@@ -149,7 +147,7 @@ fn parse_ymd_date(year: &str, month: &str, day: &str) -> Result<NaiveDate> {
     let date = NaiveDate::from_ymd_opt(year, month, day)
         .ok_or_else(|| anyhow::anyhow!("invalid date: {}-{}-{}", year, month, day))?;
 
-    if date < now {
+    if date < base_date {
         bail!("date cannot be in the past");
     }
 
@@ -161,34 +159,9 @@ mod tests {
     use super::*;
     use std::collections::HashMap;
 
-    fn ymd(y: i32, m: u32, d: u32) -> Option<NaiveDate> {
-        Some(NaiveDate::from_ymd_opt(y, m, d).unwrap())
-    }
-
-    fn next_weekday_date(weekday: Weekday) -> NaiveDate {
-        let now = now();
-        let days = now.weekday().days_since(weekday);
-        let date = if days == 0 {
-            now + TimeDelta::weeks(1)
-        } else {
-            now + TimeDelta::days(days.into())
-        };
-        date.date_naive()
-    }
-
-    fn day_month_date(day: u32, month: u32) -> NaiveDate {
-        let now = now();
-        let year = if month <= now.month() && day < now.day() {
-            now.year() + 1
-        } else {
-            now.year()
-        };
-        NaiveDate::from_ymd_opt(year, month, day).unwrap()
-    }
-
     #[test]
     fn today_() {
-        let today = today();
+        let today = NaiveDate::from_ymd_opt(2026, 01, 24).unwrap();
 
         #[rustfmt::skip]
         let test_cases = HashMap::from([
@@ -204,7 +177,7 @@ mod tests {
         ]);
 
         for (input, (expected_day, expected_purpose)) in test_cases {
-            let result = parse_message_with_date(input).unwrap();
+            let result = parse_message_with_date(today, input).unwrap();
             assert_eq!(result.day, expected_day, "Test case: `{input}`");
             assert_eq!(
                 result.purpose.as_deref(),
@@ -216,23 +189,24 @@ mod tests {
 
     #[test]
     fn tomorrow() {
-        let tomorrow_date = today() + TimeDelta::days(1);
+        let today = NaiveDate::from_ymd_opt(2026, 01, 24).unwrap();
+        let tomorrow = NaiveDate::from_ymd_opt(2026, 01, 25).unwrap();
 
         #[rustfmt::skip]
         let test_cases = HashMap::from([
-            ("завтра", (Some(tomorrow_date), None)),
-            ("Завтра", (Some(tomorrow_date), None)),
-            ("завтра, громить спейс", (Some(tomorrow_date), Some("громить спейс"))),
-            ("Завтра, громить спейс", (Some(tomorrow_date), Some("громить спейс"))),
-            ("завтра громить спейс", (Some(tomorrow_date), Some("громить спейс"))),
-            ("Завтра громить спейс", (Some(tomorrow_date), Some("громить спейс"))),
-            ("завтра   ,     ", (Some(tomorrow_date), None)),
-            ("завтра           не знаю", (Some(tomorrow_date), Some("не знаю"))),
-            ("Завтра  , Децентрализироваться", (Some(tomorrow_date), Some("Децентрализироваться"))),
+            ("завтра", (Some(tomorrow), None)),
+            ("Завтра", (Some(tomorrow), None)),
+            ("завтра, громить спейс", (Some(tomorrow), Some("громить спейс"))),
+            ("Завтра, громить спейс", (Some(tomorrow), Some("громить спейс"))),
+            ("завтра громить спейс", (Some(tomorrow), Some("громить спейс"))),
+            ("Завтра громить спейс", (Some(tomorrow), Some("громить спейс"))),
+            ("завтра   ,     ", (Some(tomorrow), None)),
+            ("завтра           не знаю", (Some(tomorrow), Some("не знаю"))),
+            ("Завтра  , Децентрализироваться", (Some(tomorrow), Some("Децентрализироваться"))),
         ]);
 
         for (input, (expected_day, expected_purpose)) in test_cases {
-            let result = parse_message_with_date(input).unwrap();
+            let result = parse_message_with_date(today, input).unwrap();
             assert_eq!(result.day, expected_day, "Test case: `{input}`");
             assert_eq!(
                 result.purpose.as_deref(),
@@ -244,23 +218,24 @@ mod tests {
 
     #[test]
     fn day_after_tomorrow() {
-        let day_after_tomorrow_date = today() + TimeDelta::days(2);
+        let today = NaiveDate::from_ymd_opt(2026, 01, 24).unwrap();
+        let day_after_tomorrow = NaiveDate::from_ymd_opt(2026, 01, 26).unwrap();
 
         #[rustfmt::skip]
         let test_cases = HashMap::from([
-            ("послезавтра", (Some(day_after_tomorrow_date), None)),
-            ("Послезавтра", (Some(day_after_tomorrow_date), None)),
-            ("послезавтра, паять паяльником", (Some(day_after_tomorrow_date), Some("паять паяльником"))),
-            ("Послезавтра, паять паяльником", (Some(day_after_tomorrow_date), Some("паять паяльником"))),
-            ("послезавтра паять паяльником", (Some(day_after_tomorrow_date), Some("паять паяльником"))),
-            ("Послезавтра паять паяльником", (Some(day_after_tomorrow_date), Some("паять паяльником"))),
-            ("послезавтра   ,     ", (Some(day_after_tomorrow_date), None)),
-            ("послезавтра           не знаю", (Some(day_after_tomorrow_date), Some("не знаю"))),
-            ("Послезавтра  ,  Думу думать", (Some(day_after_tomorrow_date), Some("Думу думать"))),
+            ("послезавтра", (Some(day_after_tomorrow), None)),
+            ("Послезавтра", (Some(day_after_tomorrow), None)),
+            ("послезавтра, паять паяльником", (Some(day_after_tomorrow), Some("паять паяльником"))),
+            ("Послезавтра, паять паяльником", (Some(day_after_tomorrow), Some("паять паяльником"))),
+            ("послезавтра паять паяльником", (Some(day_after_tomorrow), Some("паять паяльником"))),
+            ("Послезавтра паять паяльником", (Some(day_after_tomorrow), Some("паять паяльником"))),
+            ("послезавтра   ,     ", (Some(day_after_tomorrow), None)),
+            ("послезавтра           не знаю", (Some(day_after_tomorrow), Some("не знаю"))),
+            ("Послезавтра  ,  Думу думать", (Some(day_after_tomorrow), Some("Думу думать"))),
         ]);
 
         for (input, (expected_day, expected_purpose)) in test_cases {
-            let result = parse_message_with_date(input).unwrap();
+            let result = parse_message_with_date(today, input).unwrap();
             assert_eq!(result.day, expected_day, "Test case: `{input}`");
             assert_eq!(
                 result.purpose.as_deref(),
@@ -272,90 +247,100 @@ mod tests {
 
     #[test]
     fn next_weekday() {
+        let today = NaiveDate::from_ymd_opt(2026, 1, 24).unwrap();
+
+        let next_sunday = NaiveDate::from_ymd_opt(2026, 1, 25).unwrap();
+        let next_monday = NaiveDate::from_ymd_opt(2026, 1, 26).unwrap();
+        let next_tuesday = NaiveDate::from_ymd_opt(2026, 1, 27).unwrap();
+        let next_wednesday = NaiveDate::from_ymd_opt(2026, 1, 28).unwrap();
+        let next_thursday = NaiveDate::from_ymd_opt(2026, 1, 29).unwrap();
+        let next_friday = NaiveDate::from_ymd_opt(2026, 1, 30).unwrap();
+        let next_saturday = NaiveDate::from_ymd_opt(2026, 1, 31).unwrap();
+
         #[rustfmt::skip]
         let test_cases = HashMap::from([
-            ("в понедельник", (next_weekday_date(Weekday::Mon), None)),
-            ("во вторник",    (next_weekday_date(Weekday::Tue), None)),
-            ("в среду",       (next_weekday_date(Weekday::Wed), None)),
-            ("В четверг",     (next_weekday_date(Weekday::Thu), None)),
-            ("в пятницу",     (next_weekday_date(Weekday::Fri), None)),
-            ("В субботу",     (next_weekday_date(Weekday::Sat), None)),
-            ("В воскресенье", (next_weekday_date(Weekday::Sun), None)),
+            ("в понедельник", (next_monday, None)),
+            ("во вторник",    (next_tuesday, None)),
+            ("в среду",       (next_wednesday, None)),
+            ("В четверг",     (next_thursday, None)),
+            ("в пятницу",     (next_friday, None)),
+            ("В субботу",     (next_saturday, None)),
+            ("В воскресенье", (next_sunday, None)),
 
-            ("в понедельник, делать глупости", (next_weekday_date(Weekday::Mon), Some("делать глупости"))),
-            ("во вторник делать глупости", (next_weekday_date(Weekday::Tue), Some("делать глупости"))),
-            ("в среду   ,     ", (next_weekday_date(Weekday::Wed), None)),
-            ("В четверг           тусить", (next_weekday_date(Weekday::Thu), Some("тусить"))),
-            ("в пятницу  , Собирать принтер", (next_weekday_date(Weekday::Fri), Some("Собирать принтер"))),
+            ("в понедельник, делать глупости", (next_monday, Some("делать глупости"))),
+            ("во вторник делать глупости", (next_tuesday, Some("делать глупости"))),
+            ("в среду   ,     ", (next_wednesday, None)),
+            ("В четверг           тусить", (next_thursday, Some("тусить"))),
+            ("в пятницу  , Собирать принтер", (next_friday, Some("Собирать принтер"))),
 
-            ("В следующий понедельник", (next_weekday_date(Weekday::Mon), None)),
-            ("Во следующий вторник",    (next_weekday_date(Weekday::Tue), None)),
-            ("В следующую среду",       (next_weekday_date(Weekday::Wed), None)),
-            ("В следующий четверг",     (next_weekday_date(Weekday::Thu), None)),
-            ("в следующую пятницу",     (next_weekday_date(Weekday::Fri), None)),
-            ("в следующую субботу",     (next_weekday_date(Weekday::Sat), None)),
-            ("В следующее воскресенье", (next_weekday_date(Weekday::Sun), None)),
+            ("В следующий понедельник", (next_monday, None)),
+            ("Во следующий вторник",    (next_tuesday, None)),
+            ("В следующую среду",       (next_wednesday, None)),
+            ("В следующий четверг",     (next_thursday, None)),
+            ("в следующую пятницу",     (next_friday, None)),
+            ("в следующую субботу",     (next_saturday, None)),
+            ("В следующее воскресенье", (next_sunday, None)),
 
-            ("в следующий понедельник, делать глупости", (next_weekday_date(Weekday::Mon), Some("делать глупости"))),
-            ("во следующий вторник делать глупости", (next_weekday_date(Weekday::Tue), Some("делать глупости"))),
-            ("в следующую среду   ,     ", (next_weekday_date(Weekday::Wed), None)),
-            ("В следующий четверг           тусить", (next_weekday_date(Weekday::Thu), Some("тусить"))),
-            ("в следующую пятницу  , Собирать принтер", (next_weekday_date(Weekday::Fri), Some("Собирать принтер"))),
+            ("в следующий понедельник, делать глупости", (next_monday, Some("делать глупости"))),
+            ("во следующий вторник делать глупости", (next_tuesday, Some("делать глупости"))),
+            ("в следующую среду   ,     ", (next_wednesday, None)),
+            ("В следующий четверг           тусить", (next_thursday, Some("тусить"))),
+            ("в следующую пятницу  , Собирать принтер", (next_friday, Some("Собирать принтер"))),
 
-            ("пон", (next_weekday_date(Weekday::Mon), None)),
-            ("пн", (next_weekday_date(Weekday::Mon), None)),
-            ("вт", (next_weekday_date(Weekday::Tue), None)),
-            ("ср", (next_weekday_date(Weekday::Wed), None)),
-            ("чет", (next_weekday_date(Weekday::Thu), None)),
-            ("чт", (next_weekday_date(Weekday::Thu), None)),
-            ("пят", (next_weekday_date(Weekday::Fri), None)),
-            ("пт", (next_weekday_date(Weekday::Fri), None)),
-            ("суб", (next_weekday_date(Weekday::Sat), None)),
-            ("сб", (next_weekday_date(Weekday::Sat), None)),
-            ("вс", (next_weekday_date(Weekday::Sun), None)),
-            ("вск", (next_weekday_date(Weekday::Sun), None)),
-            ("вос", (next_weekday_date(Weekday::Sun), None)),
-            ("воск", (next_weekday_date(Weekday::Sun), None)),
+            ("пон", (next_monday, None)),
+            ("пн", (next_monday, None)),
+            ("вт", (next_tuesday, None)),
+            ("ср", (next_wednesday, None)),
+            ("чет", (next_thursday, None)),
+            ("чт", (next_thursday, None)),
+            ("пят", (next_friday, None)),
+            ("пт", (next_friday, None)),
+            ("суб", (next_saturday, None)),
+            ("сб", (next_saturday, None)),
+            ("вс", (next_sunday, None)),
+            ("вск", (next_sunday, None)),
+            ("вос", (next_sunday, None)),
+            ("воск", (next_sunday, None)),
 
-            ("в пн", (next_weekday_date(Weekday::Mon), None)),
-            ("во вт", (next_weekday_date(Weekday::Tue), None)),
-            ("в ср", (next_weekday_date(Weekday::Wed), None)),
-            ("В чт", (next_weekday_date(Weekday::Thu), None)),
-            ("в пт", (next_weekday_date(Weekday::Fri), None)),
-            ("В сб", (next_weekday_date(Weekday::Sat), None)),
-            ("в вс", (next_weekday_date(Weekday::Sun), None)),
-            ("во вск", (next_weekday_date(Weekday::Sun), None)),
-            ("В вос", (next_weekday_date(Weekday::Sun), None)),
-            ("в воск", (next_weekday_date(Weekday::Sun), None)),
+            ("в пн", (next_monday, None)),
+            ("во вт", (next_tuesday, None)),
+            ("в ср", (next_wednesday, None)),
+            ("В чт", (next_thursday, None)),
+            ("в пт", (next_friday, None)),
+            ("В сб", (next_saturday, None)),
+            ("в вс", (next_sunday, None)),
+            ("во вск", (next_sunday, None)),
+            ("В вос", (next_sunday, None)),
+            ("в воск", (next_sunday, None)),
 
-            ("в следующий пн", (next_weekday_date(Weekday::Mon), None)),
-            ("во следующий вт", (next_weekday_date(Weekday::Tue), None)),
-            ("в следующую ср", (next_weekday_date(Weekday::Wed), None)),
-            ("В следующий чт", (next_weekday_date(Weekday::Thu), None)),
-            ("в следующую пт", (next_weekday_date(Weekday::Fri), None)),
-            ("В следующую сб", (next_weekday_date(Weekday::Sat), None)),
-            ("в следующий вс", (next_weekday_date(Weekday::Sun), None)),
-            ("во следующий вск", (next_weekday_date(Weekday::Sun), None)),
-            ("В следующий вос", (next_weekday_date(Weekday::Sun), None)),
-            ("в следующий воск", (next_weekday_date(Weekday::Sun), None)),
+            ("в следующий пн", (next_monday, None)),
+            ("во следующий вт", (next_tuesday, None)),
+            ("в следующую ср", (next_wednesday, None)),
+            ("В следующий чт", (next_thursday, None)),
+            ("в следующую пт", (next_friday, None)),
+            ("В следующую сб", (next_saturday, None)),
+            ("в следующий вс", (next_sunday, None)),
+            ("во следующий вск", (next_sunday, None)),
+            ("В следующий вос", (next_sunday, None)),
+            ("в следующий воск", (next_sunday, None)),
 
-            ("пн, делать глупости", (next_weekday_date(Weekday::Mon), Some("делать глупости"))),
-            ("вт тусить", (next_weekday_date(Weekday::Tue), Some("тусить"))),
-            ("в ср   ,     ", (next_weekday_date(Weekday::Wed), None)),
-            ("В чт           Собирать принтер", (next_weekday_date(Weekday::Thu), Some("Собирать принтер"))),
-            ("в пт  , ловить спутники", (next_weekday_date(Weekday::Fri), Some("ловить спутники"))),
-            ("В сб ломать жопы", (next_weekday_date(Weekday::Sat), Some("ломать жопы"))),
-            ("в вс паять платы", (next_weekday_date(Weekday::Sun), Some("паять платы"))),
-            ("во вск, делать глупости", (next_weekday_date(Weekday::Sun), Some("делать глупости"))),
-            ("В вос тусить", (next_weekday_date(Weekday::Sun), Some("тусить"))),
-            ("в воск Собирать принтер", (next_weekday_date(Weekday::Sun), Some("Собирать принтер"))),
+            ("пн, делать глупости", (next_monday, Some("делать глупости"))),
+            ("вт тусить", (next_tuesday, Some("тусить"))),
+            ("в ср   ,     ", (next_wednesday, None)),
+            ("В чт           Собирать принтер", (next_thursday, Some("Собирать принтер"))),
+            ("в пт  , ловить спутники", (next_friday, Some("ловить спутники"))),
+            ("В сб ломать жопы", (next_saturday, Some("ломать жопы"))),
+            ("в вс паять платы", (next_sunday, Some("паять платы"))),
+            ("во вск, делать глупости", (next_sunday, Some("делать глупости"))),
+            ("В вос тусить", (next_sunday, Some("тусить"))),
+            ("в воск Собирать принтер", (next_sunday, Some("Собирать принтер"))),
         
-            ("в след сб", (next_weekday_date(Weekday::Sat), None)),
-            ("в след вс", (next_weekday_date(Weekday::Sun), None)),
+            ("в след сб", (next_saturday, None)),
+            ("в след вс", (next_sunday, None)),
         ]);
 
         for (input, (expected_day, expected_purpose)) in test_cases {
-            let result = parse_message_with_date(input).unwrap();
+            let result = parse_message_with_date(today, input).unwrap();
             assert_eq!(result.day, Some(expected_day), "Test case: `{input}`");
             assert_eq!(
                 result.purpose.as_deref(),
@@ -367,33 +352,34 @@ mod tests {
 
     #[test]
     fn day_month() {
+        let today = NaiveDate::from_ymd_opt(2026, 01, 24).unwrap();
+
         #[rustfmt::skip]
         let test_cases = HashMap::from([
-            ("1 января",   (day_month_date(1, 1), None)),
-            ("15 февраля", (day_month_date(15, 2), None)),
-            ("20 марта",   (day_month_date(20, 3), None)),
-            ("5 апреля",   (day_month_date(5, 4), None)),
-            ("10 мая",     (day_month_date(10, 5), None)),
-            ("25 июня",    (day_month_date(25, 6), None)),
-            ("12 июля",    (day_month_date(12, 7), None)),
-            ("31 августа", (day_month_date(31, 8), None)),
-            ("7 сентября", (day_month_date(7, 9), None)),
-            ("18 октября", (day_month_date(18, 10), None)),
-            ("23 ноября",  (day_month_date(23, 11), None)),
-            ("30 декабря", (day_month_date(30, 12), None)),
+            ("1 января",   (NaiveDate::from_ymd_opt(2027, 1, 1), None)),
+            ("23 января",  (NaiveDate::from_ymd_opt(2027, 1, 23), None)),
+            ("24 января",  (NaiveDate::from_ymd_opt(2026, 1, 24), None)),
+            ("15 февраля", (NaiveDate::from_ymd_opt(2026, 2, 15), None)),
+            ("20 марта",   (NaiveDate::from_ymd_opt(2026, 3, 20), None)),
+            ("5 апреля",   (NaiveDate::from_ymd_opt(2026, 4, 5), None)),
+            ("10 мая",     (NaiveDate::from_ymd_opt(2026, 5, 10), None)),
+            ("25 июня",    (NaiveDate::from_ymd_opt(2026, 6, 25), None)),
+            ("12 июля",    (NaiveDate::from_ymd_opt(2026, 7, 12), None)),
+            ("31 августа", (NaiveDate::from_ymd_opt(2026, 8, 31), None)),
+            ("7 сентября", (NaiveDate::from_ymd_opt(2026, 9, 7), None)),
+            ("18 октября", (NaiveDate::from_ymd_opt(2026, 10, 18), None)),
+            ("23 ноября",  (NaiveDate::from_ymd_opt(2026, 11, 23), None)),
+            ("30 декабря", (NaiveDate::from_ymd_opt(2026, 12, 30), None)),
 
-            ("1 января, ловить спутники", (day_month_date(1, 1), Some("ловить спутники"))),
-            ("15 февраля ломать жопы", (day_month_date(15, 2), Some("ломать жопы"))),
-            ("20 марта   ,     ", (day_month_date(20, 3), None)),
-            ("5 апреля           паять платы", (day_month_date(5, 4), Some("паять платы"))),
-
-            ("5 января",   (day_month_date(5, 1), None)),
-            ("25 февраля", (day_month_date(25, 2), None)),
+            ("1 января, ловить спутники", (NaiveDate::from_ymd_opt(2027, 1, 1), Some("ловить спутники"))),
+            ("15 февраля ломать жопы", (NaiveDate::from_ymd_opt(2026, 02, 15), Some("ломать жопы"))),
+            ("20 марта   ,     ", (NaiveDate::from_ymd_opt(2026, 3, 20), None)),
+            ("5 апреля           паять платы", (NaiveDate::from_ymd_opt(2026, 4, 5), Some("паять платы"))),
         ]);
 
         for (input, (expected_day, expected_purpose)) in test_cases {
-            let result = parse_message_with_date(input).unwrap();
-            assert_eq!(result.day, Some(expected_day), "Test case: `{input}`");
+            let result = parse_message_with_date(today, input).unwrap();
+            assert_eq!(result.day, expected_day, "Test case: `{input}`");
             assert_eq!(
                 result.purpose.as_deref(),
                 expected_purpose,
@@ -404,40 +390,42 @@ mod tests {
 
     #[test]
     fn ymd_format() {
+        let today = NaiveDate::from_ymd_opt(2026, 01, 24).unwrap();
+
         #[rustfmt::skip]
         let test_cases = HashMap::from([
-            ("2200.09.10", (ymd(2200, 9, 10), None)),
-            ("2200-01.01", (ymd(2200, 1, 1),  None)),
-            ("2202.1.10",  (ymd(2202, 1, 10), None)),
-            ("2200.01.10", (ymd(2200, 1, 10), None)),
-            ("2200.09-10", (ymd(2200, 9, 10), None)),
-            ("2201-01-2",  (ymd(2201, 1, 2),  None)),
-            ("2200-01-10", (ymd(2200, 1, 10), None)),
-            ("2201.01.09", (ymd(2201, 1, 9),  None)),
+            ("2200.09.10", (NaiveDate::from_ymd_opt(2200, 9, 10), None)),
+            ("2200-01.01", (NaiveDate::from_ymd_opt(2200, 1, 1),  None)),
+            ("2202.1.10",  (NaiveDate::from_ymd_opt(2202, 1, 10), None)),
+            ("2200.01.10", (NaiveDate::from_ymd_opt(2200, 1, 10), None)),
+            ("2200.09-10", (NaiveDate::from_ymd_opt(2200, 9, 10), None)),
+            ("2201-01-2",  (NaiveDate::from_ymd_opt(2201, 1, 2),  None)),
+            ("2200-01-10", (NaiveDate::from_ymd_opt(2200, 1, 10), None)),
+            ("2201.01.09", (NaiveDate::from_ymd_opt(2201, 1, 9),  None)),
             (
                 "2222.10.19, пить пиво",
-                (ymd(2222, 10, 19), Some("пить пиво"))
+                (NaiveDate::from_ymd_opt(2222, 10, 19), Some("пить пиво"))
             ),
             (
-                "3322.01-23 радоваться жизни", (
-                ymd(3322, 1, 23), Some("радоваться жизни"))
+                "3322.01-23 радоваться жизни",
+                (NaiveDate::from_ymd_opt(3322, 1, 23), Some("радоваться жизни"))
             ),
             (
                 "2230.1.1   ,     ",
-                (ymd(2230, 1, 1), None)
+                (NaiveDate::from_ymd_opt(2230, 1, 1), None)
             ),
             (
                 "3020-5.23           идти к реке",
-                (ymd(3020, 5, 23), Some("идти к реке"))
+                (NaiveDate::from_ymd_opt(3020, 5, 23), Some("идти к реке"))
             ),
             (
                 "2301.07-6  , Децентрализироваться",
-                (ymd(2301, 7, 6), Some("Децентрализироваться"))
+                (NaiveDate::from_ymd_opt(2301, 7, 6), Some("Децентрализироваться"))
             ),
         ]);
 
         for (input, (expected_day, expected_purpose)) in test_cases {
-            let result = parse_message_with_date(input).unwrap();
+            let result = parse_message_with_date(today, input).unwrap();
             assert_eq!(result.day, expected_day, "Test case: `{input}`");
             assert_eq!(
                 result.purpose.as_deref(),
@@ -449,40 +437,42 @@ mod tests {
 
     #[test]
     fn dmy_format() {
+        let today = NaiveDate::from_ymd_opt(2026, 01, 24).unwrap();
+
         #[rustfmt::skip]
         let test_cases = HashMap::from([
-            ("10.09.2200", (ymd(2200, 9, 10), None)),
-            ("01-01-2200", (ymd(2200, 1, 1),  None)),
-            ("10.1.2202",  (ymd(2202, 1, 10), None)),
-            ("10.01.2200", (ymd(2200, 1, 10), None)),
-            ("10-09-2200", (ymd(2200, 9, 10), None)),
-            ("2-01-2201",  (ymd(2201, 1, 2),  None)),
-            ("10-01-2200", (ymd(2200, 1, 10), None)),
-            ("09.01.2201", (ymd(2201, 1, 9),  None)),
+            ("10.09.2200", (NaiveDate::from_ymd_opt(2200, 9, 10), None)),
+            ("01-01-2200", (NaiveDate::from_ymd_opt(2200, 1, 1),  None)),
+            ("10.1.2202",  (NaiveDate::from_ymd_opt(2202, 1, 10), None)),
+            ("10.01.2200", (NaiveDate::from_ymd_opt(2200, 1, 10), None)),
+            ("10-09-2200", (NaiveDate::from_ymd_opt(2200, 9, 10), None)),
+            ("2-01-2201",  (NaiveDate::from_ymd_opt(2201, 1, 2),  None)),
+            ("10-01-2200", (NaiveDate::from_ymd_opt(2200, 1, 10), None)),
+            ("09.01.2201", (NaiveDate::from_ymd_opt(2201, 1, 9),  None)),
             (
                 "19.10.2222, lorem ipsum dolor",
-                (ymd(2222, 10, 19), Some("lorem ipsum dolor"))
+                (NaiveDate::from_ymd_opt(2222, 10, 19), Some("lorem ipsum dolor"))
             ),
             (
                 "23-01-3322 причина визита неизвестна", (
-                ymd(3322, 1, 23), Some("причина визита неизвестна"))
+                NaiveDate::from_ymd_opt(3322, 1, 23), Some("причина визита неизвестна"))
             ),
             (
                 "1.1.2230   ,     ",
-                (ymd(2230, 1, 1), None)
+                (NaiveDate::from_ymd_opt(2230, 1, 1), None)
             ),
             (
                 "23.5.3020           надо подумать",
-                (ymd(3020, 5, 23), Some("надо подумать"))
+                (NaiveDate::from_ymd_opt(3020, 5, 23), Some("надо подумать"))
             ),
             (
                 "6-07-2301  , Централизовываться",
-                (ymd(2301, 7, 6), Some("Централизовываться"))
+                (NaiveDate::from_ymd_opt(2301, 7, 6), Some("Централизовываться"))
             ),
         ]);
 
         for (input, (expected_day, expected_purpose)) in test_cases {
-            let result = parse_message_with_date(input).unwrap();
+            let result = parse_message_with_date(today, input).unwrap();
             assert_eq!(result.day, expected_day, "Test case: `{input}`");
             assert_eq!(
                 result.purpose.as_deref(),
@@ -494,6 +484,8 @@ mod tests {
 
     #[test]
     fn no_date() {
+        let today = NaiveDate::from_ymd_opt(2026, 01, 24).unwrap();
+
         #[rustfmt::skip]
         let test_cases = HashMap::from([
             ("просто текст", (None, Some("просто текст"))),
@@ -508,7 +500,7 @@ mod tests {
         ]);
 
         for (input, (expected_day, expected_purpose)) in test_cases {
-            let result = parse_message_with_date(input).unwrap();
+            let result = parse_message_with_date(today, input).unwrap();
             assert_eq!(result.day, expected_day, "Test case: `{input}`");
             assert_eq!(
                 result.purpose.as_deref(),
@@ -520,6 +512,8 @@ mod tests {
 
     #[test]
     fn negative() {
+        let today = NaiveDate::from_ymd_opt(2026, 01, 24).unwrap();
+
         #[rustfmt::skip]
         let invalid_cases = vec![
             "1970.01.01",  // Date in the past
@@ -533,7 +527,7 @@ mod tests {
 
         for invalid_input in invalid_cases {
             assert!(
-                parse_message_with_date(invalid_input).is_err(),
+                parse_message_with_date(today, invalid_input).is_err(),
                 "Test case: `{invalid_input}`"
             );
         }

--- a/src/date.rs
+++ b/src/date.rs
@@ -12,7 +12,9 @@ static RELATIVE_DAY: LazyLock<Regex> =
     LazyLock::new(|| regex(r"^(сегодня|завтра|послезавтра)[\s\.,]*(\s+.*)?$"));
 
 static NEXT_WEEKDAY: LazyLock<Regex> = LazyLock::new(|| {
-    regex(r"^(во?\s+)?(след(ующ..)?\s+)?(по?н(едельник)?|[Вв]т(орник)?|ср(еду)?|че?т(верг)?|пя?т(ницу)?|су?б(боту)?|во?ск?(ресенье)?)[\s\.,]*(\s+.*)?$")
+    regex(
+        r"^(во?\s+)?(след(ующ..)?\s+)?(по?н(едельник)?|[Вв]т(орник)?|ср(еду)?|че?т(верг)?|пя?т(ницу)?|су?б(боту)?|во?ск?(ресенье)?)[\s\.,]*(\s+.*)?$",
+    )
 });
 
 static DAY_MONTH: LazyLock<Regex> = LazyLock::new(|| {
@@ -104,10 +106,6 @@ fn calculate_next_weekday(base_date: NaiveDate, weekday: &str) -> NaiveDate {
     } else {
         7 - current_weekday + target_weekday
     };
-
-    println!(
-        "current_weekday = {current_weekday}, target_weekday = {target_weekday}, diff = {days}"
-    );
 
     base_date + TimeDelta::days(days.into())
 }

--- a/src/date.rs
+++ b/src/date.rs
@@ -10,10 +10,8 @@ pub struct ParsedMessage {
     pub purpose: Option<String>,
 }
 
-static TOMORROW: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^[Зз]автра\s*,?\s*(.*)").unwrap());
-
-static DAY_AFTER_TOMORROW: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^[Пп]ослезавтра\s*,?\s*(.*)").unwrap());
+static RELATIVE_DAY: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^([Сс]егодня|[Зз]автра|[Пп]ослезавтра)\s*,?\s*(.*)").unwrap());
 
 static NEXT_WEEKDAY: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"^[Вв]о?\s+((следующ..)\s+)?(понедельник|вторник|среду|четверг|пятницу|субботу|воскресенье)\s*,?\s*(.*)").unwrap()
@@ -30,15 +28,10 @@ static DMY: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^(\d{1,2})[-\.](\d{1,2})[-\.](\d{4})\s*,?\s*(.*)").unwrap());
 
 pub fn parse_message_with_date(text: &str) -> Result<ParsedMessage> {
-    if let Some(c) = TOMORROW.captures(text) {
+    if let Some(c) = RELATIVE_DAY.captures(text) {
         Ok(ParsedMessage {
-            day: Some(today() + TimeDelta::days(1)),
-            purpose: none_if_empty(&c[1]),
-        })
-    } else if let Some(c) = DAY_AFTER_TOMORROW.captures(text) {
-        Ok(ParsedMessage {
-            day: Some(today() + TimeDelta::days(2)),
-            purpose: none_if_empty(&c[1]),
+            day: Some(calculate_relative_day(&c[1])),
+            purpose: none_if_empty(&c[2]),
         })
     } else if let Some(c) = NEXT_WEEKDAY.captures(text) {
         Ok(ParsedMessage {
@@ -77,6 +70,15 @@ fn none_if_empty(text: &str) -> Option<String> {
     }
 }
 
+fn calculate_relative_day(relative_day: &str) -> NaiveDate {
+    match relative_day.to_lowercase().as_str() {
+        "сегодня" => today(),
+        "завтра" => today() + TimeDelta::days(1),
+        "послезавтра" => today() + TimeDelta::days(2),
+        _ => unreachable!("invalid word `{relative_day}`"),
+    }
+}
+
 fn calculate_next_weekday(weekday: &str) -> NaiveDate {
     let now = now();
 
@@ -88,7 +90,7 @@ fn calculate_next_weekday(weekday: &str) -> NaiveDate {
         "пятницу" => Weekday::Fri,
         "субботу" => Weekday::Sat,
         "воскресенье" => Weekday::Sun,
-        _ => unreachable!(),
+        _ => unreachable!("invalid word `{weekday}`"),
     };
 
     let days = now.weekday().days_since(weekday);
@@ -119,7 +121,7 @@ fn parse_day_month_date(day: &str, month: &str) -> Result<NaiveDate> {
         "октября" => 10,
         "ноября" => 11,
         "декабря" => 12,
-        _ => unreachable!(),
+        _ => unreachable!("invalid word `{month}`"),
     };
 
     let year = if month <= now.month() && day < now.day() {
@@ -177,6 +179,34 @@ mod tests {
             now.year()
         };
         NaiveDate::from_ymd_opt(year, month, day).unwrap()
+    }
+
+    #[test]
+    fn today_() {
+        let today = today();
+
+        #[rustfmt::skip]
+        let test_cases = HashMap::from([
+            ("сегодня", (Some(today), None)),
+            ("сегодня", (Some(today), None)),
+            ("сегодня, паять паяльником", (Some(today), Some("паять паяльником"))),
+            ("сегодня, паять паяльником", (Some(today), Some("паять паяльником"))),
+            ("сегодня паять паяльником", (Some(today), Some("паять паяльником"))),
+            ("сегодня паять паяльником", (Some(today), Some("паять паяльником"))),
+            ("сегодня   ,     ", (Some(today), None)),
+            ("сегодня           не знаю", (Some(today), Some("не знаю"))),
+            ("сегодня  ,  Думу думать", (Some(today), Some("Думу думать"))),
+        ]);
+
+        for (input, (expected_day, expected_purpose)) in test_cases {
+            let result = parse_message_with_date(input).unwrap();
+            assert_eq!(result.day, expected_day, "Test case: `{input}`");
+            assert_eq!(
+                result.purpose.as_deref(),
+                expected_purpose,
+                "Test case: `{input}`"
+            );
+        }
     }
 
     #[test]

--- a/src/date.rs
+++ b/src/date.rs
@@ -10,11 +10,12 @@ pub struct ParsedMessage {
     pub purpose: Option<String>,
 }
 
-static RELATIVE_DAY: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^([Сс]егодня|[Зз]автра|[Пп]ослезавтра)[\s\.,]*(\s+.*)?$").unwrap());
+static RELATIVE_DAY: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^([Сс]егодня|[Зз]автра|[Пп]ослезавтра)[\s\.,]*(\s+.*)?$").unwrap()
+});
 
 static NEXT_WEEKDAY: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"^([Вв]о?\s+)?(следующ..\s+)?([Пп]о?н(едельник)?|[Вв]т(орник)?|[Сс]р(еду)?|[Чч]е?т(верг)?|[Пп]я?т(ницу)?|[Сс]у?б(боту)?|[Вв]о?ск?(ресенье)?)[\s\.,]*(\s+.*)?$").unwrap()
+    Regex::new(r"^([Вв]о?\s+)?(след(ующ..)?\s+)?([Пп]о?н(едельник)?|[Вв]т(орник)?|[Сс]р(еду)?|[Чч]е?т(верг)?|[Пп]я?т(ницу)?|[Сс]у?б(боту)?|[Вв]о?ск?(ресенье)?)[\s\.,]*(\s+.*)?$").unwrap()
 });
 
 static DAY_MONTH: LazyLock<Regex> = LazyLock::new(|| {
@@ -35,8 +36,8 @@ pub fn parse_message_with_date(text: &str) -> Result<ParsedMessage> {
         })
     } else if let Some(c) = NEXT_WEEKDAY.captures(text) {
         Ok(ParsedMessage {
-            day: Some(calculate_next_weekday(&c[3])),
-            purpose: parse_purpose(c.get(11)),
+            day: Some(calculate_next_weekday(&c[4])),
+            purpose: parse_purpose(c.get(12)),
         })
     } else if let Some(c) = DAY_MONTH.captures(text) {
         Ok(ParsedMessage {
@@ -60,7 +61,7 @@ pub fn parse_message_with_date(text: &str) -> Result<ParsedMessage> {
                 Some(text.trim().to_owned())
             } else {
                 None
-            }
+            },
         })
     }
 }
@@ -348,6 +349,9 @@ mod tests {
             ("во вск, делать глупости", (next_weekday_date(Weekday::Sun), Some("делать глупости"))),
             ("В вос тусить", (next_weekday_date(Weekday::Sun), Some("тусить"))),
             ("в воск Собирать принтер", (next_weekday_date(Weekday::Sun), Some("Собирать принтер"))),
+        
+            ("в след сб", (next_weekday_date(Weekday::Sat), None)),
+            ("в след вс", (next_weekday_date(Weekday::Sun), None)),
         ]);
 
         for (input, (expected_day, expected_purpose)) in test_cases {

--- a/src/date.rs
+++ b/src/date.rs
@@ -2,7 +2,7 @@ use crate::utils::{now, today};
 
 use anyhow::{Result, bail};
 use chrono::{Datelike, NaiveDate, TimeDelta, Weekday};
-use regex::Regex;
+use regex::{Match, Regex};
 use std::sync::LazyLock;
 
 pub struct ParsedMessage {
@@ -11,60 +11,64 @@ pub struct ParsedMessage {
 }
 
 static RELATIVE_DAY: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^([Сс]егодня|[Зз]автра|[Пп]ослезавтра)\s*,?\s*(.*)").unwrap());
+    LazyLock::new(|| Regex::new(r"^([Сс]егодня|[Зз]автра|[Пп]ослезавтра)[\s\.,]*(\s+.*)?$").unwrap());
 
 static NEXT_WEEKDAY: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"^[Вв]о?\s+((следующ..)\s+)?(понедельник|вторник|среду|четверг|пятницу|субботу|воскресенье)\s*,?\s*(.*)").unwrap()
+    Regex::new(r"^([Вв]о?\s+)?(следующ..\s+)?([Пп]о?н(едельник)?|[Вв]т(орник)?|[Сс]р(еду)?|[Чч]е?т(верг)?|[Пп]я?т(ницу)?|[Сс]у?б(боту)?|[Вв]о?ск?(ресенье)?)[\s\.,]*(\s+.*)?$").unwrap()
 });
 
 static DAY_MONTH: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"^(\d{1,2})\s+(января|февраля|марта|апреля|мая|июня|июля|августа|сентября|октября|ноября|декабря)\s*,?\s*(.*)").unwrap()
+    Regex::new(r"^(\d{1,2})\s+(января|февраля|марта|апреля|мая|июня|июля|августа|сентября|октября|ноября|декабря)[\s\.,]*(\s+.*)?$").unwrap()
 });
 
 static YMD: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^(\d{4})[-\.](\d{1,2})[-\.](\d{1,2})\s*,?\s*(.*)").unwrap());
+    LazyLock::new(|| Regex::new(r"^(\d{4})[-\.](\d{1,2})[-\.](\d{1,2})[\s\.,]*(\s+.*)?$").unwrap());
 
 static DMY: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^(\d{1,2})[-\.](\d{1,2})[-\.](\d{4})\s*,?\s*(.*)").unwrap());
+    LazyLock::new(|| Regex::new(r"^(\d{1,2})[-\.](\d{1,2})[-\.](\d{4})[\s\.,]*(\s+.*)?$").unwrap());
 
 pub fn parse_message_with_date(text: &str) -> Result<ParsedMessage> {
     if let Some(c) = RELATIVE_DAY.captures(text) {
         Ok(ParsedMessage {
             day: Some(calculate_relative_day(&c[1])),
-            purpose: none_if_empty(&c[2]),
+            purpose: parse_purpose(c.get(2)),
         })
     } else if let Some(c) = NEXT_WEEKDAY.captures(text) {
         Ok(ParsedMessage {
             day: Some(calculate_next_weekday(&c[3])),
-            purpose: none_if_empty(&c[4]),
+            purpose: parse_purpose(c.get(11)),
         })
     } else if let Some(c) = DAY_MONTH.captures(text) {
         Ok(ParsedMessage {
             day: Some(parse_day_month_date(&c[1], &c[2])?),
-            purpose: none_if_empty(&c[3]),
+            purpose: parse_purpose(c.get(3)),
         })
     } else if let Some(c) = YMD.captures(text) {
         Ok(ParsedMessage {
             day: Some(parse_ymd_date(&c[1], &c[2], &c[3])?),
-            purpose: none_if_empty(&c[4]),
+            purpose: parse_purpose(c.get(4)),
         })
     } else if let Some(c) = DMY.captures(text) {
         Ok(ParsedMessage {
             day: Some(parse_ymd_date(&c[3], &c[2], &c[1])?),
-            purpose: none_if_empty(&c[4]),
+            purpose: parse_purpose(c.get(4)),
         })
     } else {
         Ok(ParsedMessage {
             day: None,
-            purpose: none_if_empty(text),
+            purpose: if !text.trim().is_empty() {
+                Some(text.trim().to_owned())
+            } else {
+                None
+            }
         })
     }
 }
 
-fn none_if_empty(text: &str) -> Option<String> {
-    let text = text.trim();
-    if !text.is_empty() {
-        Some(text.to_owned())
+fn parse_purpose(purpose: Option<Match<'_>>) -> Option<String> {
+    let purpose = purpose?.as_str().trim();
+    if !purpose.is_empty() {
+        Some(purpose.to_owned())
     } else {
         None
     }
@@ -83,13 +87,13 @@ fn calculate_next_weekday(weekday: &str) -> NaiveDate {
     let now = now();
 
     let weekday = match weekday {
-        "понедельник" => Weekday::Mon,
-        "вторник" => Weekday::Tue,
-        "среду" => Weekday::Wed,
-        "четверг" => Weekday::Thu,
-        "пятницу" => Weekday::Fri,
-        "субботу" => Weekday::Sat,
-        "воскресенье" => Weekday::Sun,
+        "понедельник" | "пон" | "пн" => Weekday::Mon,
+        "вторник" | "вт" => Weekday::Tue,
+        "среду" | "ср" => Weekday::Wed,
+        "четверг" | "чет" | "чт" => Weekday::Thu,
+        "пятницу" | "пят" | "пт" => Weekday::Fri,
+        "субботу" | "суб" | "сб" => Weekday::Sat,
+        "воскресенье" | "вс" | "вск" | "вос" | "воск" => Weekday::Sun,
         _ => unreachable!("invalid word `{weekday}`"),
     };
 
@@ -296,6 +300,54 @@ mod tests {
             ("в следующую среду   ,     ", (next_weekday_date(Weekday::Wed), None)),
             ("В следующий четверг           тусить", (next_weekday_date(Weekday::Thu), Some("тусить"))),
             ("в следующую пятницу  , Собирать принтер", (next_weekday_date(Weekday::Fri), Some("Собирать принтер"))),
+
+            ("пон", (next_weekday_date(Weekday::Mon), None)),
+            ("пн", (next_weekday_date(Weekday::Mon), None)),
+            ("вт", (next_weekday_date(Weekday::Tue), None)),
+            ("ср", (next_weekday_date(Weekday::Wed), None)),
+            ("чет", (next_weekday_date(Weekday::Thu), None)),
+            ("чт", (next_weekday_date(Weekday::Thu), None)),
+            ("пят", (next_weekday_date(Weekday::Fri), None)),
+            ("пт", (next_weekday_date(Weekday::Fri), None)),
+            ("суб", (next_weekday_date(Weekday::Sat), None)),
+            ("сб", (next_weekday_date(Weekday::Sat), None)),
+            ("вс", (next_weekday_date(Weekday::Sun), None)),
+            ("вск", (next_weekday_date(Weekday::Sun), None)),
+            ("вос", (next_weekday_date(Weekday::Sun), None)),
+            ("воск", (next_weekday_date(Weekday::Sun), None)),
+
+            ("в пн", (next_weekday_date(Weekday::Mon), None)),
+            ("во вт", (next_weekday_date(Weekday::Tue), None)),
+            ("в ср", (next_weekday_date(Weekday::Wed), None)),
+            ("В чт", (next_weekday_date(Weekday::Thu), None)),
+            ("в пт", (next_weekday_date(Weekday::Fri), None)),
+            ("В сб", (next_weekday_date(Weekday::Sat), None)),
+            ("в вс", (next_weekday_date(Weekday::Sun), None)),
+            ("во вск", (next_weekday_date(Weekday::Sun), None)),
+            ("В вос", (next_weekday_date(Weekday::Sun), None)),
+            ("в воск", (next_weekday_date(Weekday::Sun), None)),
+
+            ("в следующий пн", (next_weekday_date(Weekday::Mon), None)),
+            ("во следующий вт", (next_weekday_date(Weekday::Tue), None)),
+            ("в следующую ср", (next_weekday_date(Weekday::Wed), None)),
+            ("В следующий чт", (next_weekday_date(Weekday::Thu), None)),
+            ("в следующую пт", (next_weekday_date(Weekday::Fri), None)),
+            ("В следующую сб", (next_weekday_date(Weekday::Sat), None)),
+            ("в следующий вс", (next_weekday_date(Weekday::Sun), None)),
+            ("во следующий вск", (next_weekday_date(Weekday::Sun), None)),
+            ("В следующий вос", (next_weekday_date(Weekday::Sun), None)),
+            ("в следующий воск", (next_weekday_date(Weekday::Sun), None)),
+
+            ("пн, делать глупости", (next_weekday_date(Weekday::Mon), Some("делать глупости"))),
+            ("вт тусить", (next_weekday_date(Weekday::Tue), Some("тусить"))),
+            ("в ср   ,     ", (next_weekday_date(Weekday::Wed), None)),
+            ("В чт           Собирать принтер", (next_weekday_date(Weekday::Thu), Some("Собирать принтер"))),
+            ("в пт  , ловить спутники", (next_weekday_date(Weekday::Fri), Some("ловить спутники"))),
+            ("В сб ломать жопы", (next_weekday_date(Weekday::Sat), Some("ломать жопы"))),
+            ("в вс паять платы", (next_weekday_date(Weekday::Sun), Some("паять платы"))),
+            ("во вск, делать глупости", (next_weekday_date(Weekday::Sun), Some("делать глупости"))),
+            ("В вос тусить", (next_weekday_date(Weekday::Sun), Some("тусить"))),
+            ("в воск Собирать принтер", (next_weekday_date(Weekday::Sun), Some("Собирать принтер"))),
         ]);
 
         for (input, (expected_day, expected_purpose)) in test_cases {
@@ -447,6 +499,8 @@ mod tests {
             ("встреча завтра но не сегодня", (None, Some("встреча завтра но не сегодня"))),
             ("10/01/2026", (None, Some("10/01/2026"))),
             ("9 лепня 2026", (None, Some("9 лепня 2026"))),
+            ("Сегодняшний вечер перестаёт быть томным", (None, Some("Сегодняшний вечер перестаёт быть томным"))),
+            ("Воскресный день", (None, Some("Воскресный день"))),
         ]);
 
         for (input, (expected_day, expected_purpose)) in test_cases {

--- a/src/date.rs
+++ b/src/date.rs
@@ -1,0 +1,453 @@
+use crate::utils::{now, today};
+
+use anyhow::{Result, bail};
+use chrono::{Datelike, NaiveDate, TimeDelta, Weekday};
+use regex::Regex;
+use std::sync::LazyLock;
+
+pub struct ParsedMessage {
+    pub day: Option<NaiveDate>,
+    pub purpose: Option<String>,
+}
+
+static TOMORROW: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^[Зз]автра\s*,?\s*(.*)").unwrap());
+
+static DAY_AFTER_TOMORROW: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^[Пп]ослезавтра\s*,?\s*(.*)").unwrap());
+
+static NEXT_WEEKDAY: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^[Вв]о?\s+((следующ..)\s+)?(понедельник|вторник|среду|четверг|пятницу|субботу|воскресенье)\s*,?\s*(.*)").unwrap()
+});
+
+static DAY_MONTH: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"^(\d{1,2})\s+(января|февраля|марта|апреля|мая|июня|июля|августа|сентября|октября|ноября|декабря)\s*,?\s*(.*)").unwrap()
+});
+
+static YMD: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^(\d{4})[-\.](\d{1,2})[-\.](\d{1,2})\s*,?\s*(.*)").unwrap());
+
+static DMY: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^(\d{1,2})[-\.](\d{1,2})[-\.](\d{4})\s*,?\s*(.*)").unwrap());
+
+pub fn parse_message_with_date(text: &str) -> Result<ParsedMessage> {
+    if let Some(c) = TOMORROW.captures(text) {
+        Ok(ParsedMessage {
+            day: Some(today() + TimeDelta::days(1)),
+            purpose: none_if_empty(&c[1]),
+        })
+    } else if let Some(c) = DAY_AFTER_TOMORROW.captures(text) {
+        Ok(ParsedMessage {
+            day: Some(today() + TimeDelta::days(2)),
+            purpose: none_if_empty(&c[1]),
+        })
+    } else if let Some(c) = NEXT_WEEKDAY.captures(text) {
+        Ok(ParsedMessage {
+            day: Some(calculate_next_weekday(&c[3])),
+            purpose: none_if_empty(&c[4]),
+        })
+    } else if let Some(c) = DAY_MONTH.captures(text) {
+        Ok(ParsedMessage {
+            day: Some(parse_day_month_date(&c[1], &c[2])?),
+            purpose: none_if_empty(&c[3]),
+        })
+    } else if let Some(c) = YMD.captures(text) {
+        Ok(ParsedMessage {
+            day: Some(parse_ymd_date(&c[1], &c[2], &c[3])?),
+            purpose: none_if_empty(&c[4]),
+        })
+    } else if let Some(c) = DMY.captures(text) {
+        Ok(ParsedMessage {
+            day: Some(parse_ymd_date(&c[3], &c[2], &c[1])?),
+            purpose: none_if_empty(&c[4]),
+        })
+    } else {
+        Ok(ParsedMessage {
+            day: None,
+            purpose: none_if_empty(text),
+        })
+    }
+}
+
+fn none_if_empty(text: &str) -> Option<String> {
+    let text = text.trim();
+    if !text.is_empty() {
+        Some(text.to_owned())
+    } else {
+        None
+    }
+}
+
+fn calculate_next_weekday(weekday: &str) -> NaiveDate {
+    let now = now();
+
+    let weekday = match weekday {
+        "понедельник" => Weekday::Mon,
+        "вторник" => Weekday::Tue,
+        "среду" => Weekday::Wed,
+        "четверг" => Weekday::Thu,
+        "пятницу" => Weekday::Fri,
+        "субботу" => Weekday::Sat,
+        "воскресенье" => Weekday::Sun,
+        _ => unreachable!(),
+    };
+
+    let days = now.weekday().days_since(weekday);
+    let date = if days == 0 {
+        now + TimeDelta::weeks(1)
+    } else {
+        now + TimeDelta::days(days.into())
+    };
+
+    date.date_naive()
+}
+
+fn parse_day_month_date(day: &str, month: &str) -> Result<NaiveDate> {
+    let now = now();
+
+    let day = day.parse().unwrap();
+
+    let month = match month {
+        "января" => 1,
+        "февраля" => 2,
+        "марта" => 3,
+        "апреля" => 4,
+        "мая" => 5,
+        "июня" => 6,
+        "июля" => 7,
+        "августа" => 8,
+        "сентября" => 9,
+        "октября" => 10,
+        "ноября" => 11,
+        "декабря" => 12,
+        _ => unreachable!(),
+    };
+
+    let year = if month <= now.month() && day < now.day() {
+        now.year() + 1
+    } else {
+        now.year()
+    };
+
+    NaiveDate::from_ymd_opt(year, month, day)
+        .ok_or_else(|| anyhow::anyhow!("invalid date: {}-{}-{}", year, month, day))
+}
+
+fn parse_ymd_date(year: &str, month: &str, day: &str) -> Result<NaiveDate> {
+    let now = today();
+
+    let year = year.parse().unwrap();
+    let month = month.parse().unwrap();
+    let day = day.parse().unwrap();
+
+    let date = NaiveDate::from_ymd_opt(year, month, day)
+        .ok_or_else(|| anyhow::anyhow!("invalid date: {}-{}-{}", year, month, day))?;
+
+    if date < now {
+        bail!("date cannot be in the past");
+    }
+
+    Ok(date)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn ymd(y: i32, m: u32, d: u32) -> Option<NaiveDate> {
+        Some(NaiveDate::from_ymd_opt(y, m, d).unwrap())
+    }
+
+    fn next_weekday_date(weekday: Weekday) -> NaiveDate {
+        let now = now();
+        let days = now.weekday().days_since(weekday);
+        let date = if days == 0 {
+            now + TimeDelta::weeks(1)
+        } else {
+            now + TimeDelta::days(days.into())
+        };
+        date.date_naive()
+    }
+
+    fn day_month_date(day: u32, month: u32) -> NaiveDate {
+        let now = now();
+        let year = if month <= now.month() && day < now.day() {
+            now.year() + 1
+        } else {
+            now.year()
+        };
+        NaiveDate::from_ymd_opt(year, month, day).unwrap()
+    }
+
+    #[test]
+    fn tomorrow() {
+        let tomorrow_date = today() + TimeDelta::days(1);
+
+        #[rustfmt::skip]
+        let test_cases = HashMap::from([
+            ("завтра", (Some(tomorrow_date), None)),
+            ("Завтра", (Some(tomorrow_date), None)),
+            ("завтра, громить спейс", (Some(tomorrow_date), Some("громить спейс"))),
+            ("Завтра, громить спейс", (Some(tomorrow_date), Some("громить спейс"))),
+            ("завтра громить спейс", (Some(tomorrow_date), Some("громить спейс"))),
+            ("Завтра громить спейс", (Some(tomorrow_date), Some("громить спейс"))),
+            ("завтра   ,     ", (Some(tomorrow_date), None)),
+            ("завтра           не знаю", (Some(tomorrow_date), Some("не знаю"))),
+            ("Завтра  , Децентрализироваться", (Some(tomorrow_date), Some("Децентрализироваться"))),
+        ]);
+
+        for (input, (expected_day, expected_purpose)) in test_cases {
+            let result = parse_message_with_date(input).unwrap();
+            assert_eq!(result.day, expected_day, "Test case: `{input}`");
+            assert_eq!(
+                result.purpose.as_deref(),
+                expected_purpose,
+                "Test case: `{input}`"
+            );
+        }
+    }
+
+    #[test]
+    fn day_after_tomorrow() {
+        let day_after_tomorrow_date = today() + TimeDelta::days(2);
+
+        #[rustfmt::skip]
+        let test_cases = HashMap::from([
+            ("послезавтра", (Some(day_after_tomorrow_date), None)),
+            ("Послезавтра", (Some(day_after_tomorrow_date), None)),
+            ("послезавтра, паять паяльником", (Some(day_after_tomorrow_date), Some("паять паяльником"))),
+            ("Послезавтра, паять паяльником", (Some(day_after_tomorrow_date), Some("паять паяльником"))),
+            ("послезавтра паять паяльником", (Some(day_after_tomorrow_date), Some("паять паяльником"))),
+            ("Послезавтра паять паяльником", (Some(day_after_tomorrow_date), Some("паять паяльником"))),
+            ("послезавтра   ,     ", (Some(day_after_tomorrow_date), None)),
+            ("послезавтра           не знаю", (Some(day_after_tomorrow_date), Some("не знаю"))),
+            ("Послезавтра  ,  Думу думать", (Some(day_after_tomorrow_date), Some("Думу думать"))),
+        ]);
+
+        for (input, (expected_day, expected_purpose)) in test_cases {
+            let result = parse_message_with_date(input).unwrap();
+            assert_eq!(result.day, expected_day, "Test case: `{input}`");
+            assert_eq!(
+                result.purpose.as_deref(),
+                expected_purpose,
+                "Test case: `{input}`"
+            );
+        }
+    }
+
+    #[test]
+    fn next_weekday() {
+        #[rustfmt::skip]
+        let test_cases = HashMap::from([
+            ("в понедельник", (next_weekday_date(Weekday::Mon), None)),
+            ("во вторник",    (next_weekday_date(Weekday::Tue), None)),
+            ("в среду",       (next_weekday_date(Weekday::Wed), None)),
+            ("В четверг",     (next_weekday_date(Weekday::Thu), None)),
+            ("в пятницу",     (next_weekday_date(Weekday::Fri), None)),
+            ("В субботу",     (next_weekday_date(Weekday::Sat), None)),
+            ("В воскресенье", (next_weekday_date(Weekday::Sun), None)),
+
+            ("в понедельник, делать глупости", (next_weekday_date(Weekday::Mon), Some("делать глупости"))),
+            ("во вторник делать глупости", (next_weekday_date(Weekday::Tue), Some("делать глупости"))),
+            ("в среду   ,     ", (next_weekday_date(Weekday::Wed), None)),
+            ("В четверг           тусить", (next_weekday_date(Weekday::Thu), Some("тусить"))),
+            ("в пятницу  , Собирать принтер", (next_weekday_date(Weekday::Fri), Some("Собирать принтер"))),
+
+            ("В следующий понедельник", (next_weekday_date(Weekday::Mon), None)),
+            ("Во следующий вторник",    (next_weekday_date(Weekday::Tue), None)),
+            ("В следующую среду",       (next_weekday_date(Weekday::Wed), None)),
+            ("В следующий четверг",     (next_weekday_date(Weekday::Thu), None)),
+            ("в следующую пятницу",     (next_weekday_date(Weekday::Fri), None)),
+            ("в следующую субботу",     (next_weekday_date(Weekday::Sat), None)),
+            ("В следующее воскресенье", (next_weekday_date(Weekday::Sun), None)),
+
+            ("в следующий понедельник, делать глупости", (next_weekday_date(Weekday::Mon), Some("делать глупости"))),
+            ("во следующий вторник делать глупости", (next_weekday_date(Weekday::Tue), Some("делать глупости"))),
+            ("в следующую среду   ,     ", (next_weekday_date(Weekday::Wed), None)),
+            ("В следующий четверг           тусить", (next_weekday_date(Weekday::Thu), Some("тусить"))),
+            ("в следующую пятницу  , Собирать принтер", (next_weekday_date(Weekday::Fri), Some("Собирать принтер"))),
+        ]);
+
+        for (input, (expected_day, expected_purpose)) in test_cases {
+            let result = parse_message_with_date(input).unwrap();
+            assert_eq!(result.day, Some(expected_day), "Test case: `{input}`");
+            assert_eq!(
+                result.purpose.as_deref(),
+                expected_purpose,
+                "Test case: `{input}`"
+            );
+        }
+    }
+
+    #[test]
+    fn day_month() {
+        #[rustfmt::skip]
+        let test_cases = HashMap::from([
+            ("1 января",   (day_month_date(1, 1), None)),
+            ("15 февраля", (day_month_date(15, 2), None)),
+            ("20 марта",   (day_month_date(20, 3), None)),
+            ("5 апреля",   (day_month_date(5, 4), None)),
+            ("10 мая",     (day_month_date(10, 5), None)),
+            ("25 июня",    (day_month_date(25, 6), None)),
+            ("12 июля",    (day_month_date(12, 7), None)),
+            ("31 августа", (day_month_date(31, 8), None)),
+            ("7 сентября", (day_month_date(7, 9), None)),
+            ("18 октября", (day_month_date(18, 10), None)),
+            ("23 ноября",  (day_month_date(23, 11), None)),
+            ("30 декабря", (day_month_date(30, 12), None)),
+
+            ("1 января, ловить спутники", (day_month_date(1, 1), Some("ловить спутники"))),
+            ("15 февраля ломать жопы", (day_month_date(15, 2), Some("ломать жопы"))),
+            ("20 марта   ,     ", (day_month_date(20, 3), None)),
+            ("5 апреля           паять платы", (day_month_date(5, 4), Some("паять платы"))),
+
+            ("5 января",   (day_month_date(5, 1), None)),
+            ("25 февраля", (day_month_date(25, 2), None)),
+        ]);
+
+        for (input, (expected_day, expected_purpose)) in test_cases {
+            let result = parse_message_with_date(input).unwrap();
+            assert_eq!(result.day, Some(expected_day), "Test case: `{input}`");
+            assert_eq!(
+                result.purpose.as_deref(),
+                expected_purpose,
+                "Test case: `{input}`"
+            );
+        }
+    }
+
+    #[test]
+    fn ymd_format() {
+        #[rustfmt::skip]
+        let test_cases = HashMap::from([
+            ("2200.09.10", (ymd(2200, 9, 10), None)),
+            ("2200-01.01", (ymd(2200, 1, 1),  None)),
+            ("2202.1.10",  (ymd(2202, 1, 10), None)),
+            ("2200.01.10", (ymd(2200, 1, 10), None)),
+            ("2200.09-10", (ymd(2200, 9, 10), None)),
+            ("2201-01-2",  (ymd(2201, 1, 2),  None)),
+            ("2200-01-10", (ymd(2200, 1, 10), None)),
+            ("2201.01.09", (ymd(2201, 1, 9),  None)),
+            (
+                "2222.10.19, пить пиво",
+                (ymd(2222, 10, 19), Some("пить пиво"))
+            ),
+            (
+                "3322.01-23 радоваться жизни", (
+                ymd(3322, 1, 23), Some("радоваться жизни"))
+            ),
+            (
+                "2230.1.1   ,     ",
+                (ymd(2230, 1, 1), None)
+            ),
+            (
+                "3020-5.23           идти к реке",
+                (ymd(3020, 5, 23), Some("идти к реке"))
+            ),
+            (
+                "2301.07-6  , Децентрализироваться",
+                (ymd(2301, 7, 6), Some("Децентрализироваться"))
+            ),
+        ]);
+
+        for (input, (expected_day, expected_purpose)) in test_cases {
+            let result = parse_message_with_date(input).unwrap();
+            assert_eq!(result.day, expected_day, "Test case: `{input}`");
+            assert_eq!(
+                result.purpose.as_deref(),
+                expected_purpose,
+                "Test case: `{input}`"
+            );
+        }
+    }
+
+    #[test]
+    fn dmy_format() {
+        #[rustfmt::skip]
+        let test_cases = HashMap::from([
+            ("10.09.2200", (ymd(2200, 9, 10), None)),
+            ("01-01-2200", (ymd(2200, 1, 1),  None)),
+            ("10.1.2202",  (ymd(2202, 1, 10), None)),
+            ("10.01.2200", (ymd(2200, 1, 10), None)),
+            ("10-09-2200", (ymd(2200, 9, 10), None)),
+            ("2-01-2201",  (ymd(2201, 1, 2),  None)),
+            ("10-01-2200", (ymd(2200, 1, 10), None)),
+            ("09.01.2201", (ymd(2201, 1, 9),  None)),
+            (
+                "19.10.2222, lorem ipsum dolor",
+                (ymd(2222, 10, 19), Some("lorem ipsum dolor"))
+            ),
+            (
+                "23-01-3322 причина визита неизвестна", (
+                ymd(3322, 1, 23), Some("причина визита неизвестна"))
+            ),
+            (
+                "1.1.2230   ,     ",
+                (ymd(2230, 1, 1), None)
+            ),
+            (
+                "23.5.3020           надо подумать",
+                (ymd(3020, 5, 23), Some("надо подумать"))
+            ),
+            (
+                "6-07-2301  , Централизовываться",
+                (ymd(2301, 7, 6), Some("Централизовываться"))
+            ),
+        ]);
+
+        for (input, (expected_day, expected_purpose)) in test_cases {
+            let result = parse_message_with_date(input).unwrap();
+            assert_eq!(result.day, expected_day, "Test case: `{input}`");
+            assert_eq!(
+                result.purpose.as_deref(),
+                expected_purpose,
+                "Test case: `{input}`"
+            );
+        }
+    }
+
+    #[test]
+    fn no_date() {
+        #[rustfmt::skip]
+        let test_cases = HashMap::from([
+            ("просто текст", (None, Some("просто текст"))),
+            ("", (None, None)),
+            ("   ", (None, None)),
+            ("какая-то случайная строка", (None, Some("какая-то случайная строка"))),
+            ("встреча завтра но не сегодня", (None, Some("встреча завтра но не сегодня"))),
+            ("10/01/2026", (None, Some("10/01/2026"))),
+            ("9 лепня 2026", (None, Some("9 лепня 2026"))),
+        ]);
+
+        for (input, (expected_day, expected_purpose)) in test_cases {
+            let result = parse_message_with_date(input).unwrap();
+            assert_eq!(result.day, expected_day, "Test case: `{input}`");
+            assert_eq!(
+                result.purpose.as_deref(),
+                expected_purpose,
+                "Test case: `{input}`"
+            );
+        }
+    }
+
+    #[test]
+    fn negative() {
+        #[rustfmt::skip]
+        let invalid_cases = vec![
+            "1970.01.01",  // Date in the past
+            "2026.00-01",  // Invalid month
+            "2026.01.00",  // Invalid day
+            "2026-13-01",  // Invalid month
+            "40 июня",     // Invalid day for June (max 30)
+            "30 февраля",  // Invalid day for February (max 28/29)
+            "32 января",   // Invalid day for January (max 31)
+        ];
+
+        for invalid_input in invalid_cases {
+            assert!(
+                parse_message_with_date(invalid_input).is_err(),
+                "Test case: `{invalid_input}`"
+            );
+        }
+    }
+}

--- a/src/date.rs
+++ b/src/date.rs
@@ -1,6 +1,6 @@
 use anyhow::{Result, bail};
 use chrono::{Datelike, NaiveDate, TimeDelta, Weekday};
-use regex::{Match, Regex};
+use regex::{Match, Regex, RegexBuilder};
 use std::sync::LazyLock;
 
 pub struct ParsedMessage {
@@ -8,23 +8,24 @@ pub struct ParsedMessage {
     pub purpose: Option<String>,
 }
 
-static RELATIVE_DAY: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"^([Сс]егодня|[Зз]автра|[Пп]ослезавтра)[\s\.,]*(\s+.*)?$").unwrap()
-});
+static RELATIVE_DAY: LazyLock<Regex> =
+    LazyLock::new(|| regex(r"^(сегодня|завтра|послезавтра)[\s\.,]*(\s+.*)?$"));
 
 static NEXT_WEEKDAY: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"^([Вв]о?\s+)?(след(ующ..)?\s+)?([Пп]о?н(едельник)?|[Вв]т(орник)?|[Сс]р(еду)?|[Чч]е?т(верг)?|[Пп]я?т(ницу)?|[Сс]у?б(боту)?|[Вв]о?ск?(ресенье)?)[\s\.,]*(\s+.*)?$").unwrap()
+    regex(r"^(во?\s+)?(след(ующ..)?\s+)?(по?н(едельник)?|[Вв]т(орник)?|ср(еду)?|че?т(верг)?|пя?т(ницу)?|су?б(боту)?|во?ск?(ресенье)?)[\s\.,]*(\s+.*)?$")
 });
 
 static DAY_MONTH: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"^(\d{1,2})\s+(января|февраля|марта|апреля|мая|июня|июля|августа|сентября|октября|ноября|декабря)[\s\.,]*(\s+.*)?$").unwrap()
+    regex(
+        r"^(\d{1,2})\s+(января|февраля|марта|апреля|мая|июня|июля|августа|сентября|октября|ноября|декабря)[\s\.,]*(\s+.*)?$",
+    )
 });
 
 static YMD: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^(\d{4})[-\.](\d{1,2})[-\.](\d{1,2})[\s\.,]*(\s+.*)?$").unwrap());
+    LazyLock::new(|| regex(r"^(\d{4})[-\.](\d{1,2})[-\.](\d{1,2})[\s\.,]*(\s+.*)?$"));
 
 static DMY: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^(\d{1,2})[-\.](\d{1,2})[-\.](\d{4})[\s\.,]*(\s+.*)?$").unwrap());
+    LazyLock::new(|| regex(r"^(\d{1,2})[-\.](\d{1,2})[-\.](\d{4})[\s\.,]*(\s+.*)?$"));
 
 pub fn parse_message_with_date(base_date: NaiveDate, text: &str) -> Result<ParsedMessage> {
     if let Some(c) = RELATIVE_DAY.captures(text) {
@@ -64,13 +65,12 @@ pub fn parse_message_with_date(base_date: NaiveDate, text: &str) -> Result<Parse
     }
 }
 
-fn parse_purpose(purpose: Option<Match<'_>>) -> Option<String> {
-    let purpose = purpose?.as_str().trim();
-    if !purpose.is_empty() {
-        Some(purpose.to_owned())
-    } else {
-        None
-    }
+fn regex(pattern: &str) -> Regex {
+    RegexBuilder::new(pattern)
+        .unicode(true)
+        .case_insensitive(true)
+        .build()
+        .expect("pattern should be valid")
 }
 
 fn calculate_relative_day(base_date: NaiveDate, relative_day: &str) -> NaiveDate {
@@ -97,15 +97,17 @@ fn calculate_next_weekday(base_date: NaiveDate, weekday: &str) -> NaiveDate {
     let current_weekday = base_date.weekday().number_from_monday();
     let target_weekday = target_weekday.number_from_monday();
 
-    let days = if current_weekday == target_weekday{
+    let days = if current_weekday == target_weekday {
         7
-    }else if current_weekday < target_weekday {
+    } else if current_weekday < target_weekday {
         target_weekday - current_weekday
     } else {
         7 - current_weekday + target_weekday
     };
 
-    println!("current_weekday = {current_weekday}, target_weekday = {target_weekday}, diff = {days}");
+    println!(
+        "current_weekday = {current_weekday}, target_weekday = {target_weekday}, diff = {days}"
+    );
 
     base_date + TimeDelta::days(days.into())
 }
@@ -152,6 +154,15 @@ fn parse_ymd_date(base_date: NaiveDate, year: &str, month: &str, day: &str) -> R
     }
 
     Ok(date)
+}
+
+fn parse_purpose(purpose: Option<Match<'_>>) -> Option<String> {
+    let purpose = purpose?.as_str().trim();
+    if !purpose.is_empty() {
+        Some(purpose.to_owned())
+    } else {
+        None
+    }
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,10 @@
 pub mod backend;
 pub mod bot;
 pub mod config;
+pub mod date;
 pub mod rest_api;
 pub mod utils;
 pub mod visits;
-pub mod date;
 
 pub use bot::TelegramBot;
 pub use config::Config;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod config;
 pub mod rest_api;
 pub mod utils;
 pub mod visits;
+pub mod date;
 
 pub use bot::TelegramBot;
 pub use config::Config;


### PR DESCRIPTION
Раньше бот понимал только фразы "завтра" и "послезавтра", а так же не умел удалять запятую для сообщений вида "/planvisit завтра, пить боржоми".

Этот PR добавляет поддержку дат в форматах:
- Сегодня
- В (следующий) вторник
- 25 января
- 20.10.2026
- 2026.10.20

Новый парсер так же учитывает, что после даты может идти запятая.

Всё написано на регекспах, каждый регексп обложен толстым слоем тестов в файле `date.rs`.